### PR TITLE
Adding additional configuration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -139,6 +139,8 @@ Maven Configuration
        <artifactId>karma-maven-plugin</artifactId>
        <version>2.1</version>
        <configuration>
+          <nodeLocation>node</nodeLocation> <!-- The command needed to run node, wherever it may be ->
+          <karmaLocation>karma</karma> <!-- The command needed to run karma, wherever it may be -->
           <templateFile>karma-template.cfg.js</templateFile> <!-- the file the plugin picks up and replaces stuff in -->
           <karmaFile>karma-runner.cfg.js</karmaFile> <!-- this is the file that gets generated, that Karma runs -->
           <karmaLocalisation>${user.home}/.karma</karmaLocalisation> <!-- where to find the local karma file -->

--- a/src/main/groovy/com/bluetrainsoftware/maven/karma/KarmaBaseMojo.groovy
+++ b/src/main/groovy/com/bluetrainsoftware/maven/karma/KarmaBaseMojo.groovy
@@ -45,6 +45,9 @@ class KarmaBaseMojo extends AbstractMojo {
   @Parameter(property = "run.nodeLocation")
   protected String nodeLocation = "node";
 
+  @Parameter(property="run.karmaLocation")
+  protected String karmaLocation = "karma";
+
   Map<String, String> karmaDirectories = new HashMap<>()
 
   protected void karmaDirectory(Artifact artifact, String directory) {
@@ -209,9 +212,9 @@ class KarmaBaseMojo extends AbstractMojo {
     ProcessBuilder builder
 
     if (File.separator == '\\') // Windows
-      builder = new ProcessBuilder("cmd", "/C", nodeLocation, "karma", "start", configFile.absolutePath)
+      builder = new ProcessBuilder("cmd", "/C", nodeLocation, karmaLocation, "start", configFile.absolutePath)
     else
-      builder = new ProcessBuilder(nodeLocation, "karma", "start", configFile.absolutePath);
+      builder = new ProcessBuilder(nodeLocation, karmaLocation, "start", configFile.absolutePath);
 
     List<String> command = builder.command();
 

--- a/src/main/groovy/com/bluetrainsoftware/maven/karma/KarmaBaseMojo.groovy
+++ b/src/main/groovy/com/bluetrainsoftware/maven/karma/KarmaBaseMojo.groovy
@@ -42,6 +42,9 @@ class KarmaBaseMojo extends AbstractMojo {
   @Parameter(property = "run.karmaLocalisation", defaultValue = "\${user.home}/.karma/")
   protected String localisationFileName
 
+  @Parameter(property = "run.nodeLocation")
+  protected String nodeLocation = "node";
+
   Map<String, String> karmaDirectories = new HashMap<>()
 
   protected void karmaDirectory(Artifact artifact, String directory) {
@@ -206,9 +209,9 @@ class KarmaBaseMojo extends AbstractMojo {
     ProcessBuilder builder
 
     if (File.separator == '\\') // Windows
-      builder = new ProcessBuilder("cmd", "/C", "karma", "start", configFile.absolutePath)
+      builder = new ProcessBuilder("cmd", "/C", nodeLocation, "karma", "start", configFile.absolutePath)
     else
-      builder = new ProcessBuilder("karma", "start", configFile.absolutePath);
+      builder = new ProcessBuilder(nodeLocation, "karma", "start", configFile.absolutePath);
 
     List<String> command = builder.command();
 


### PR DESCRIPTION
Making the location of node and karma configurable means that if in an unusual place, they can be specified. This helps when integrating with the [frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin).